### PR TITLE
Added command line option parsing.  Unified both image and video detection into yolo_video.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ python convert.py yolov3.cfg yolov3.weights model_data/yolo.h5
 python yolo.py   OR   python yolo_video.py [video_path] [output_path(optional)]
 ```
 
-For Tiny YOLOv3, just do in a similar way. And modify model path and anchor path in yolo.py.
+For Tiny YOLOv3, just do in a similar way, just specify model path and anchor path by calling yolo.py with `--model model_file` and `--anchors anchor_file`.
 
 ---
 
-4. MultiGPU usage is an optinal. Change the number of gpu and add gpu device id
+4. MultiGPU usage: use `--gpu_num N` to use N GPUs. It is passed to the [Keras multi_gpu_model()](https://keras.io/utils/#multi_gpu_model).
 
 ## Training
 
@@ -46,8 +46,8 @@ For Tiny YOLOv3, just do in a similar way. And modify model path and anchor path
 
 3. Modify train.py and start training.  
     `python train.py`  
-    Use your trained weights or checkpoint weights in yolo.py.  
-    Remember to modify class path or anchor path.
+    Use your trained weights or checkpoint weights by adding `--model model_file` when calling yolo.py.  
+    Remember to modify class path or anchor path, with `--classes class_file` and `--anchors anchor_file`.
 
 If you want to use original pretrained weights for YOLOv3:  
     1. `wget https://pjreddie.com/media/files/darknet53.conv.74`  

--- a/README.md
+++ b/README.md
@@ -18,11 +18,26 @@ A Keras implementation of YOLOv3 (Tensorflow backend) inspired by [allanzelener/
 ```
 wget https://pjreddie.com/media/files/yolov3.weights
 python convert.py yolov3.cfg yolov3.weights model_data/yolo.h5
-python yolo.py   OR   python yolo_video.py [video_path] [output_path(optional)]
+python yolo.py   OR   python yolo_video.py [video_path] [--output output_path (optional)]
 ```
 
 For Tiny YOLOv3, just do in a similar way, just specify model path and anchor path by calling yolo.py with `--model model_file` and `--anchors anchor_file`.
 
+### Usage
+Use --help to see usage for both yolo.py and yolo_video.py:
+```
+usage: yolo.py [-h] [--model MODEL] [--anchors ANCHORS] [--classes CLASSES]
+               [--gpu_num GPU_NUM]
+
+```
+
+yolo_video.py needs an input video path from command line, and has an optional --output output_video_path:
+```
+usage: yolo_video.py [-h] [--model MODEL] [--anchors ANCHORS]
+                     [--classes CLASSES] [--gpu_num GPU_NUM] [--output OUTPUT]
+                     video_path
+
+```
 ---
 
 4. MultiGPU usage: use `--gpu_num N` to use N GPUs. It is passed to the [Keras multi_gpu_model()](https://keras.io/utils/#multi_gpu_model).

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Use --help to see usage of yolo_video.py:
 ```
 usage: yolo_video.py [-h] [--model MODEL] [--anchors ANCHORS]
                      [--classes CLASSES] [--gpu_num GPU_NUM] [--image]
-                     [video_input] [video_output]
+                     [--input] [--output]
 
 positional arguments:
-  video_input        Video input path
-  video_output       Video output path
+  --input        Video input path
+  --output       Video output path
 
 optional arguments:
   -h, --help         show this help message and exit

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For Tiny YOLOv3, just do in a similar way, just specify model path and anchor pa
 Use --help to see usage of yolo_video.py:
 ```
 usage: yolo_video.py [-h] [--model MODEL] [--anchors ANCHORS]
-                     [--classes CLASSES] [--gpu_num GPU_NUM] [-i]
+                     [--classes CLASSES] [--gpu_num GPU_NUM] [--image]
                      [video_input] [video_output]
 
 positional arguments:
@@ -43,7 +43,7 @@ optional arguments:
   --classes CLASSES  path to class definitions, default
                      model_data/coco_classes.txt
   --gpu_num GPU_NUM  Number of GPU to use, default 1
-  -i, --image        image detetion mode, will ignore all positional arguments
+  --image            Image detection mode, will ignore all positional arguments
 ```
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,25 +18,32 @@ A Keras implementation of YOLOv3 (Tensorflow backend) inspired by [allanzelener/
 ```
 wget https://pjreddie.com/media/files/yolov3.weights
 python convert.py yolov3.cfg yolov3.weights model_data/yolo.h5
-python yolo.py   OR   python yolo_video.py [video_path] [--output output_path (optional)]
+python yolo_video.py [OPTIONS...] --image, for image detection mode, OR
+python yolo_video.py [video_path] [output_path (optional)]
 ```
 
-For Tiny YOLOv3, just do in a similar way, just specify model path and anchor path by calling yolo.py with `--model model_file` and `--anchors anchor_file`.
+For Tiny YOLOv3, just do in a similar way, just specify model path and anchor path with `--model model_file` and `--anchors anchor_file`.
 
 ### Usage
-Use --help to see usage for both yolo.py and yolo_video.py:
-```
-usage: yolo.py [-h] [--model MODEL] [--anchors ANCHORS] [--classes CLASSES]
-               [--gpu_num GPU_NUM]
-
-```
-
-yolo_video.py needs an input video path from command line, and has an optional --output output_video_path:
+Use --help to see usage of yolo_video.py:
 ```
 usage: yolo_video.py [-h] [--model MODEL] [--anchors ANCHORS]
-                     [--classes CLASSES] [--gpu_num GPU_NUM] [--output OUTPUT]
-                     video_path
+                     [--classes CLASSES] [--gpu_num GPU_NUM] [-i]
+                     [video_input] [video_output]
 
+positional arguments:
+  video_input        Video input path
+  video_output       Video output path
+
+optional arguments:
+  -h, --help         show this help message and exit
+  --model MODEL      path to model weight file, default model_data/yolo.h5
+  --anchors ANCHORS  path to anchor definitions, default
+                     model_data/yolo_anchors.txt
+  --classes CLASSES  path to class definitions, default
+                     model_data/coco_classes.txt
+  --gpu_num GPU_NUM  Number of GPU to use, default 1
+  -i, --image        image detetion mode, will ignore all positional arguments
 ```
 ---
 
@@ -61,7 +68,7 @@ usage: yolo_video.py [-h] [--model MODEL] [--anchors ANCHORS]
 
 3. Modify train.py and start training.  
     `python train.py`  
-    Use your trained weights or checkpoint weights by adding `--model model_file` when calling yolo.py.  
+    Use your trained weights or checkpoint weights with command line option `--model model_file` when using yolo_video.py
     Remember to modify class path or anchor path, with `--classes class_file` and `--anchors anchor_file`.
 
 If you want to use original pretrained weights for YOLOv3:  

--- a/yolo.py
+++ b/yolo.py
@@ -173,6 +173,50 @@ class YOLO(object):
     def close_session(self):
         self.sess.close()
 
+def detect_video(yolo, video_path, output_path=""):
+    if output_path != "":
+        isOutput = True
+        print("Output Video Path: " , type(output_path))
+    else:
+        isOutput = False
+    vid = cv2.VideoCapture(video_path)
+    if not vid.isOpened():
+        raise IOError("Couldn't open webcam or video")
+    video_FourCC    = int(vid.get(cv2.CAP_PROP_FOURCC))
+    video_fps       = vid.get(cv2.CAP_PROP_FPS)
+    video_size      = (int(vid.get(cv2.CAP_PROP_FRAME_WIDTH)),
+                        int(vid.get(cv2.CAP_PROP_FRAME_HEIGHT)))
+    if isOutput:
+        print("!!! TYPE:", type(output_path), type(video_FourCC), type(video_fps), type(video_size))
+        out = cv2.VideoWriter(output_path, video_FourCC, video_fps, video_size)
+    accum_time = 0
+    curr_fps = 0
+    fps = "FPS: ??"
+    prev_time = timer()
+    while True:
+        return_value, frame = vid.read()
+        image = Image.fromarray(frame)
+        image = yolo.detect_image(image)
+        result = np.asarray(image)
+        curr_time = timer()
+        exec_time = curr_time - prev_time
+        prev_time = curr_time
+        accum_time = accum_time + exec_time
+        curr_fps = curr_fps + 1
+        if accum_time > 1:
+            accum_time = accum_time - 1
+            fps = "FPS: " + str(curr_fps)
+            curr_fps = 0
+        cv2.putText(result, text=fps, org=(3, 15), fontFace=cv2.FONT_HERSHEY_SIMPLEX,
+                    fontScale=0.50, color=(255, 0, 0), thickness=2)
+        cv2.namedWindow("result", cv2.WINDOW_NORMAL)
+        cv2.imshow("result", result)
+        if isOutput:
+            out.write(result)
+        if cv2.waitKey(1) & 0xFF == ord('q'):
+            break
+    yolo.close_session()
+
 def detect_img(yolo):
     while True:
         img = input('Input image filename:')

--- a/yolo.py
+++ b/yolo.py
@@ -177,7 +177,7 @@ def detect_video(yolo, video_path, output_path=""):
     import cv2
     if output_path != "":
         isOutput = True
-        print("Output Video Path: " , type(output_path))
+        print("Output Video Path: " + output_path)
     else:
         isOutput = False
     vid = cv2.VideoCapture(video_path)

--- a/yolo.py
+++ b/yolo.py
@@ -174,6 +174,7 @@ class YOLO(object):
         self.sess.close()
 
 def detect_video(yolo, video_path, output_path=""):
+    import cv2
     if output_path != "":
         isOutput = True
         print("Output Video Path: " , type(output_path))

--- a/yolo.py
+++ b/yolo.py
@@ -1,7 +1,6 @@
-#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Run a YOLO_v3 style detection model on test images.
+Class definition of YOLO_v3 style detection model on image and video
 """
 
 import colorsys

--- a/yolo.py
+++ b/yolo.py
@@ -19,9 +19,6 @@ from yolo3.utils import letterbox_image
 import os
 from keras.utils import multi_gpu_model
 
-import argparse
-FLAGS = None
-
 class YOLO(object):
     _defaults = {
         "model_path": 'model_data/yolo.h5',
@@ -175,11 +172,6 @@ class YOLO(object):
 
 def detect_video(yolo, video_path, output_path=""):
     import cv2
-    if output_path != "":
-        isOutput = True
-        print("Output Video Path: " + output_path)
-    else:
-        isOutput = False
     vid = cv2.VideoCapture(video_path)
     if not vid.isOpened():
         raise IOError("Couldn't open webcam or video")
@@ -187,6 +179,7 @@ def detect_video(yolo, video_path, output_path=""):
     video_fps       = vid.get(cv2.CAP_PROP_FPS)
     video_size      = (int(vid.get(cv2.CAP_PROP_FRAME_WIDTH)),
                         int(vid.get(cv2.CAP_PROP_FRAME_HEIGHT)))
+    isOutput = True if output_path != "" else False
     if isOutput:
         print("!!! TYPE:", type(output_path), type(video_FourCC), type(video_fps), type(video_size))
         out = cv2.VideoWriter(output_path, video_FourCC, video_fps, video_size)
@@ -218,51 +211,3 @@ def detect_video(yolo, video_path, output_path=""):
             break
     yolo.close_session()
 
-def detect_img(yolo):
-    while True:
-        img = input('Input image filename:')
-        try:
-            image = Image.open(img)
-        except:
-            print('Open Error! Try again!')
-            continue
-        else:
-            r_image = yolo.detect_image(image)
-            r_image.show()
-    yolo.close_session()
-
-def yolo_parser():
-    # The default values are defined in the the class YOLO above, 
-    # thus suppress any default from the argparser here, if the option is not specified from the command line.
-    parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS)
-
-    parser.add_argument(
-      '--model',
-      type=str,
-      help='path to model weight file, default ' + YOLO.get_defaults("model_path")
-    )
-
-    parser.add_argument(
-      '--anchors',
-      type=str,
-      help='path to anchor definitions, default '  + YOLO.get_defaults("anchors_path")
-    )
-
-    parser.add_argument(
-      '--classes',
-      type=str,
-      help='path to class definitions, default '  + YOLO.get_defaults("classes_path")
-    )
-
-    parser.add_argument(
-      '--gpu_num',
-      type=int,
-      help='Number of GPU to use, default ' + str(YOLO.get_defaults("gpu_num"))
-    )
-    return parser
-
-if __name__ == '__main__':
-    parser = yolo_parser()
-    FLAGS, unparsed = parser.parse_known_args()
-
-    detect_img(YOLO(**vars(FLAGS)))

--- a/yolo_video.py
+++ b/yolo_video.py
@@ -1,22 +1,70 @@
 import sys
 import argparse
-from yolo import YOLO, yolo_parser, detect_video
+from yolo import YOLO, detect_video
+from PIL import Image
 
+
+def detect_img(yolo):
+    while True:
+        img = input('Input image filename:')
+        try:
+            image = Image.open(img)
+        except:
+            print('Open Error! Try again!')
+            continue
+        else:
+            r_image = yolo.detect_image(image)
+            r_image.show()
+    yolo.close_session()
 
 FLAGS = None
 
 if __name__ == '__main__':
-    parser = yolo_parser()
+    # class YOLO defines the default value, so suppress any default here
+    parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS)
 
-    # Add the video_path and optional output video_path to the default cmdline options supported by class YOLO
-    parser.add_argument("video_path", help="input video path")
     parser.add_argument(
-      '--output',
-      type=str,
-      default="",
-      help='[optional] output video path'
+        '--model', type=str,
+        help='path to model weight file, default ' + YOLO.get_defaults("model_path")
+    )
+
+    parser.add_argument(
+        '--anchors', type=str,
+        help='path to anchor definitions, default ' + YOLO.get_defaults("anchors_path")
+    )
+
+    parser.add_argument(
+        '--classes', type=str,
+        help='path to class definitions, default ' + YOLO.get_defaults("classes_path")
+    )
+
+    parser.add_argument(
+        '--gpu_num', type=int,
+        help='Number of GPU to use, default ' + str(YOLO.get_defaults("gpu_num"))
+    )
+
+    parser.add_argument(
+        '-i', '--image', default=False, action="store_true",
+        help='image detetion mode, will ignore all positional arguments'
+    )
+
+    parser.add_argument(
+        "video_input", nargs='?', type=str,
+        help = "Video input path"
+    )
+
+    parser.add_argument(
+        "video_output", nargs='?', type=str, default="",
+        help = "[Optional] Video output path"
     )
 
     FLAGS = parser.parse_args()
 
-    detect_video(YOLO(**vars(FLAGS)), FLAGS.video_path, FLAGS.output)
+    if FLAGS.image:
+        print("Image detection mode, ignoring other command line arguments.")
+        detect_img(YOLO(**vars(FLAGS)))
+    elif "video_input" not in FLAGS:
+        print(parser.print_help())
+        print("Must specify at least vide_input_path")
+    else:
+        detect_video(YOLO(**vars(FLAGS)), FLAGS.video_input, FLAGS.video_output)

--- a/yolo_video.py
+++ b/yolo_video.py
@@ -1,16 +1,71 @@
 import sys
+import cv2
+import argparse
+from yolo import YOLO, yolo_parser
 
+def detect_video(yolo, video_path, output_path=""):
+    if output_path != "":
+        isOutput = True
+        print("Output Video Path: " , type(output_path))
+    else:
+        isOutput = False
+    vid = cv2.VideoCapture(video_path)
+    if not vid.isOpened():
+        raise IOError("Couldn't open webcam or video")
+    video_FourCC    = int(vid.get(cv2.CAP_PROP_FOURCC))
+    video_fps       = vid.get(cv2.CAP_PROP_FPS)
+    video_size      = (int(vid.get(cv2.CAP_PROP_FRAME_WIDTH)),
+                        int(vid.get(cv2.CAP_PROP_FRAME_HEIGHT)))
+    if isOutput:
+        print("!!! TYPE:", type(output_path), type(video_FourCC), type(video_fps), type(video_size))
+        out = cv2.VideoWriter(output_path, video_FourCC, video_fps, video_size)
+    accum_time = 0
+    curr_fps = 0
+    fps = "FPS: ??"
+    prev_time = timer()
+    while True:
+        return_value, frame = vid.read()
+        image = Image.fromarray(frame)
+        image = yolo.detect_image(image)
+        result = np.asarray(image)
+        curr_time = timer()
+        exec_time = curr_time - prev_time
+        prev_time = curr_time
+        accum_time = accum_time + exec_time
+        curr_fps = curr_fps + 1
+        if accum_time > 1:
+            accum_time = accum_time - 1
+            fps = "FPS: " + str(curr_fps)
+            curr_fps = 0
+        cv2.putText(result, text=fps, org=(3, 15), fontFace=cv2.FONT_HERSHEY_SIMPLEX,
+                    fontScale=0.50, color=(255, 0, 0), thickness=2)
+        cv2.namedWindow("result", cv2.WINDOW_NORMAL)
+        cv2.imshow("result", result)
+        if isOutput:
+            out.write(result)
+        if cv2.waitKey(1) & 0xFF == ord('q'):
+            break
+    yolo.close_session()
+
+
+PARSED_ARGS = None
+'''
 if len(sys.argv) < 2:
     print("Usage: $ python {0} [video_path] [output_path(optional)]", sys.argv[0])
     exit()
-
-from yolo import YOLO
-from yolo import detect_video
-
+'''
 if __name__ == '__main__':
-    video_path = sys.argv[1]
-    if len(sys.argv) > 2:
-        output_path = sys.argv[2]
-        detect_video(YOLO(), video_path, output_path)
-    else:
-        detect_video(YOLO(), video_path)
+    parser = yolo_parser()
+
+    # Add the video_path and optional output video_path to the default cmdline options supported by class YOLO
+    parser.add_argument("video_path", help="input video path")
+    parser.add_argument(
+      '--output',
+      type=str,
+      default="",
+      help='[optional] output video path'
+    )
+
+    PARSED_ARGS = parser.parse_args()
+
+    detect_video(YOLO(**vars(PARSED_ARGS)), PARSED_ARGS.video_path, PARSED_ARGS.output)

--- a/yolo_video.py
+++ b/yolo_video.py
@@ -52,12 +52,12 @@ if __name__ == '__main__':
     Command line positional arguments -- for video detection mode
     '''
     parser.add_argument(
-        "video_input", nargs='?', type=str,
+        "--input", nargs='?', type=str,required=False,default='./path2your_video',
         help = "Video input path"
     )
 
     parser.add_argument(
-        "video_output", nargs='?', type=str, default="",
+        "--output", nargs='?', type=str, default="",
         help = "[Optional] Video output path"
     )
 
@@ -68,10 +68,10 @@ if __name__ == '__main__':
         Image detection mode, disregard any remaining command line arguments
         """
         print("Image detection mode")
-        if "video_input" in FLAGS:
-            print(" Ignoring remaining command line arguments: " + FLAGS.video_input + "," + FLAGS.video_output)
+        if "input" in FLAGS:
+            print(" Ignoring remaining command line arguments: " + FLAGS.input + "," + FLAGS.output)
         detect_img(YOLO(**vars(FLAGS)))
-    elif "video_input" in FLAGS:
-        detect_video(YOLO(**vars(FLAGS)), FLAGS.video_input, FLAGS.video_output)
+    elif "input" in FLAGS:
+        detect_video(YOLO(**vars(FLAGS)), FLAGS.input, FLAGS.output)
     else:
-        print("Must specify at least vide_input_path.  See usage with --help.")
+        print("Must specify at least video_input_path.  See usage with --help.")

--- a/yolo_video.py
+++ b/yolo_video.py
@@ -1,59 +1,11 @@
 import sys
 import cv2
 import argparse
-from yolo import YOLO, yolo_parser
-
-def detect_video(yolo, video_path, output_path=""):
-    if output_path != "":
-        isOutput = True
-        print("Output Video Path: " , type(output_path))
-    else:
-        isOutput = False
-    vid = cv2.VideoCapture(video_path)
-    if not vid.isOpened():
-        raise IOError("Couldn't open webcam or video")
-    video_FourCC    = int(vid.get(cv2.CAP_PROP_FOURCC))
-    video_fps       = vid.get(cv2.CAP_PROP_FPS)
-    video_size      = (int(vid.get(cv2.CAP_PROP_FRAME_WIDTH)),
-                        int(vid.get(cv2.CAP_PROP_FRAME_HEIGHT)))
-    if isOutput:
-        print("!!! TYPE:", type(output_path), type(video_FourCC), type(video_fps), type(video_size))
-        out = cv2.VideoWriter(output_path, video_FourCC, video_fps, video_size)
-    accum_time = 0
-    curr_fps = 0
-    fps = "FPS: ??"
-    prev_time = timer()
-    while True:
-        return_value, frame = vid.read()
-        image = Image.fromarray(frame)
-        image = yolo.detect_image(image)
-        result = np.asarray(image)
-        curr_time = timer()
-        exec_time = curr_time - prev_time
-        prev_time = curr_time
-        accum_time = accum_time + exec_time
-        curr_fps = curr_fps + 1
-        if accum_time > 1:
-            accum_time = accum_time - 1
-            fps = "FPS: " + str(curr_fps)
-            curr_fps = 0
-        cv2.putText(result, text=fps, org=(3, 15), fontFace=cv2.FONT_HERSHEY_SIMPLEX,
-                    fontScale=0.50, color=(255, 0, 0), thickness=2)
-        cv2.namedWindow("result", cv2.WINDOW_NORMAL)
-        cv2.imshow("result", result)
-        if isOutput:
-            out.write(result)
-        if cv2.waitKey(1) & 0xFF == ord('q'):
-            break
-    yolo.close_session()
+from yolo import YOLO, yolo_parser, detect_video
 
 
-PARSED_ARGS = None
-'''
-if len(sys.argv) < 2:
-    print("Usage: $ python {0} [video_path] [output_path(optional)]", sys.argv[0])
-    exit()
-'''
+FLAGS = None
+
 if __name__ == '__main__':
     parser = yolo_parser()
 
@@ -66,6 +18,6 @@ if __name__ == '__main__':
       help='[optional] output video path'
     )
 
-    PARSED_ARGS = parser.parse_args()
+    FLAGS = parser.parse_args()
 
-    detect_video(YOLO(**vars(PARSED_ARGS)), PARSED_ARGS.video_path, PARSED_ARGS.output)
+    detect_video(YOLO(**vars(FLAGS)), FLAGS.video_path, FLAGS.output)

--- a/yolo_video.py
+++ b/yolo_video.py
@@ -1,5 +1,4 @@
 import sys
-import cv2
 import argparse
 from yolo import YOLO, yolo_parser, detect_video
 

--- a/yolo_video.py
+++ b/yolo_video.py
@@ -3,7 +3,6 @@ import argparse
 from yolo import YOLO, detect_video
 from PIL import Image
 
-
 def detect_img(yolo):
     while True:
         img = input('Input image filename:')
@@ -22,7 +21,9 @@ FLAGS = None
 if __name__ == '__main__':
     # class YOLO defines the default value, so suppress any default here
     parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS)
-
+    '''
+    Command line options
+    '''
     parser.add_argument(
         '--model', type=str,
         help='path to model weight file, default ' + YOLO.get_defaults("model_path")
@@ -44,10 +45,12 @@ if __name__ == '__main__':
     )
 
     parser.add_argument(
-        '-i', '--image', default=False, action="store_true",
-        help='image detetion mode, will ignore all positional arguments'
+        '--image', default=False, action="store_true",
+        help='Image detection mode, will ignore all positional arguments'
     )
-
+    '''
+    Command line positional arguments -- for video detection mode
+    '''
     parser.add_argument(
         "video_input", nargs='?', type=str,
         help = "Video input path"
@@ -61,10 +64,14 @@ if __name__ == '__main__':
     FLAGS = parser.parse_args()
 
     if FLAGS.image:
-        print("Image detection mode, ignoring other command line arguments.")
+        """
+        Image detection mode, disregard any remaining command line arguments
+        """
+        print("Image detection mode")
+        if "video_input" in FLAGS:
+            print(" Ignoring remaining command line arguments: " + FLAGS.video_input + "," + FLAGS.video_output)
         detect_img(YOLO(**vars(FLAGS)))
-    elif "video_input" not in FLAGS:
-        print(parser.print_help())
-        print("Must specify at least vide_input_path")
-    else:
+    elif "video_input" in FLAGS:
         detect_video(YOLO(**vars(FLAGS)), FLAGS.video_input, FLAGS.video_output)
+    else:
+        print("Must specify at least vide_input_path.  See usage with --help.")


### PR DESCRIPTION
Per discussion in change request #146 : 

`yolo.py`: 
- Grouped all hard-coded defaults into a hash inside class YOLO.
- Moved `detect_img()` out to `yolo_video.py`.
- Dropped __main__ calling, now it is a pure class definition file.

`yolo_video.py`:
- Added command line option parsing for `--model, --classes, --anchors, --gpu_num, --image`.
- Added `detect_img()` from `yolo.py`

`README.md`:
- Updated with usage of yolo_video.py

New usage from `yolo_video.py -h`:
```
usage: yolo_video.py [-h] [--model MODEL] [--anchors ANCHORS]
                     [--classes CLASSES] [--gpu_num GPU_NUM] [--image]
                     [video_input] [video_output]

positional arguments:
  video_input        Video input path
  video_output       [Optional] Video output path

optional arguments:
  -h, --help         show this help message and exit
  --model MODEL      path to model weight file, default model_data/yolo.h5
  --anchors ANCHORS  path to anchor definitions, default
                     model_data/yolo_anchors.txt
  --classes CLASSES  path to class definitions, default
                     model_data/coco_classes.txt
  --gpu_num GPU_NUM  Number of GPU to use, default 1
  --image            Image detection mode, will ignore all positional
                     arguments
```