### PR TITLE
fatal issue in arguments

### DIFF
--- a/yolo_video.py
+++ b/yolo_video.py
@@ -25,17 +25,17 @@ if __name__ == '__main__':
     Command line options
     '''
     parser.add_argument(
-        '--model', type=str,
+        '--model', dest='model_path', type=str,
         help='path to model weight file, default ' + YOLO.get_defaults("model_path")
     )
 
     parser.add_argument(
-        '--anchors', type=str,
+        '--anchors', dest='anchors_path', type=str,
         help='path to anchor definitions, default ' + YOLO.get_defaults("anchors_path")
     )
 
     parser.add_argument(
-        '--classes', type=str,
+        '--classes', dest='classes_path', type=str,
         help='path to class definitions, default ' + YOLO.get_defaults("classes_path")
     )
 


### PR DESCRIPTION
I've tried to run:
```shell
python yolo_video.py --model model_data/yolov3-tiny.h5 --anchors model_data/tiny_yolo_anchors.txt --image
```
if you don't use `dest=''`, parameters can not be loaded in `yolo.py`, so an error occurs.