### PR TITLE
Changed classes to classes_path

### DIFF
--- a/yolo_video.py
+++ b/yolo_video.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
     )
 
     parser.add_argument(
-        '--classes', type=str,
+        '--classes_path', type=str,
         help='path to class definitions, default ' + YOLO.get_defaults("classes_path")
     )
 


### PR DESCRIPTION
The `classes` command line argument is fed to the `YOLO` class in `yolo.py` as `classes: name (str)` when it should be `classes_path: name (str)`. The easy fix is to make the command line argument in this file, `yolo_video.py`, consistent with the naming in `yolo.py`'s `YOLO` class and have both be named `classes_path`.