### PR TITLE
Update convert.py

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -42,7 +42,7 @@ def unique_config_sections(config_file):
     Adds unique suffixes to config sections for compability with configparser.
     """
     section_counters = defaultdict(int)
-    output_stream = io.StringIO()
+    output_stream = io.BytesIO()
     with open(config_file) as fin:
         for line in fin:
             if line.startswith('['):


### PR DESCRIPTION
fix for TypeError: unicode argument expected, got 'str'