### PR TITLE
update README.md Quick Start parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A Keras implementation of YOLOv3 (Tensorflow backend) inspired by [allanzelener/
 wget https://pjreddie.com/media/files/yolov3.weights
 python convert.py yolov3.cfg yolov3.weights model_data/yolo.h5
 python yolo_video.py [OPTIONS...] --image, for image detection mode, OR
-python yolo_video.py [video_path] [output_path (optional)]
+python yolo_video.py --input [video_path] --output [output_path (optional)]
 ```
 
 For Tiny YOLOv3, just do in a similar way, just specify model path and anchor path with `--model model_file` and `--anchors anchor_file`.


### PR DESCRIPTION
python yolo_video.py [video_path] [output_path (optional)]
If you do it like this,
have the following error
yolo_video.py: error: unrecognized arguments: [video_path] [output_path (optional)]
So I changed it.

Thank you!