### PR TITLE
fix parameters' name in yolo_video.py

### DIFF
--- a/yolo_video.py
+++ b/yolo_video.py
@@ -25,17 +25,17 @@ if __name__ == '__main__':
     Command line options
     '''
     parser.add_argument(
-        '--model', type=str,
+        '--model-path', type=str,
         help='path to model weight file, default ' + YOLO.get_defaults("model_path")
     )
 
     parser.add_argument(
-        '--anchors', type=str,
+        '--anchors-path', type=str,
         help='path to anchor definitions, default ' + YOLO.get_defaults("anchors_path")
     )
 
     parser.add_argument(
-        '--classes', type=str,
+        '--classes-path', type=str,
         help='path to class definitions, default ' + YOLO.get_defaults("classes_path")
     )
 


### PR DESCRIPTION
This PR fixes #220. 

Some parameters in `yolo_video.py` don't work.
I fix following parameters.

* `--model` to `--model-path`
* `--anchors` to `--anchors-path`
* `--classes` to `--classes-path`