### PR TITLE
fix the bug of parsing argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ python yolo_video.py [OPTIONS...] --image, for image detection mode, OR
 python yolo_video.py [video_path] [output_path (optional)]
 ```
 
-For Tiny YOLOv3, just do in a similar way, just specify model path and anchor path with `--model model_file` and `--anchors anchor_file`.
+For Tiny YOLOv3, just do in a similar way, just specify model path and anchor path with `-m model_file` and `-a anchor_file`.
 
 ### Usage
 Use --help to see usage of yolo_video.py:
@@ -37,17 +37,17 @@ positional arguments:
 
 optional arguments:
   -h, --help         show this help message and exit
-  --model MODEL      path to model weight file, default model_data/yolo.h5
-  --anchors ANCHORS  path to anchor definitions, default
+  --model_path MODEL      path to model weight file, default model_data/yolo.h5
+  --anchors_path ANCHORS  path to anchor definitions, default
                      model_data/yolo_anchors.txt
-  --classes CLASSES  path to class definitions, default
+  --classes_path CLASSES  path to class definitions, default
                      model_data/coco_classes.txt
   --gpu_num GPU_NUM  Number of GPU to use, default 1
   --image            Image detection mode, will ignore all positional arguments
 ```
 ---
 
-4. MultiGPU usage: use `--gpu_num N` to use N GPUs. It is passed to the [Keras multi_gpu_model()](https://keras.io/utils/#multi_gpu_model).
+1. MultiGPU usage: use `--gpu_num N` to use N GPUs. It is passed to the [Keras multi_gpu_model()](https://keras.io/utils/#multi_gpu_model).
 
 ## Training
 

--- a/yolo_video.py
+++ b/yolo_video.py
@@ -25,17 +25,17 @@ if __name__ == '__main__':
     Command line options
     '''
     parser.add_argument(
-        '--model', type=str,
+        '-m','--model_path', type=str,
         help='path to model weight file, default ' + YOLO.get_defaults("model_path")
     )
 
     parser.add_argument(
-        '--anchors', type=str,
+        '-a','--anchors_path', type=str,
         help='path to anchor definitions, default ' + YOLO.get_defaults("anchors_path")
     )
 
     parser.add_argument(
-        '--classes', type=str,
+        '-c','--classes_path', type=str,
         help='path to class definitions, default ' + YOLO.get_defaults("classes_path")
     )
 


### PR DESCRIPTION
fixes #571.

When use our own parameters, previous argparse didn't work. 

I try to change the name of  the following parameters to fix this:
`--model` to `--model-path`
`--anchors` to `--anchors-path`
`--classes` to `--classes-path`

In addition, I change the corresponding patameter in README.md