### PR TITLE
fix parameter names in yolo.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.weights
 *.h5
 logs/
+model_data/*.cfg
 *_test.py
 
 # Byte-compiled / optimized / DLL files

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ positional arguments:
 
 optional arguments:
   -h, --help         show this help message and exit
-  --model MODEL      path to model weight file, default model_data/yolo.h5
+  --model_path MODEL      path to model weight file, default model_data/yolo.h5
   --anchors ANCHORS  path to anchor definitions, default
                      model_data/yolo_anchors.txt
-  --classes CLASSES  path to class definitions, default
+  --classes_path CLASSES  path to class definitions, default
                      model_data/coco_classes.txt
   --gpu_num GPU_NUM  Number of GPU to use, default 1
   --image            Image detection mode, will ignore all positional arguments

--- a/yolo_video.py
+++ b/yolo_video.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     Command line options
     '''
     parser.add_argument(
-        '--model', type=str,
+        '--model_path', type=str,
         help='path to model weight file, default ' + YOLO.get_defaults("model_path")
     )
 
@@ -35,7 +35,7 @@ if __name__ == '__main__':
     )
 
     parser.add_argument(
-        '--classes', type=str,
+        '--classes_path', type=str,
         help='path to class definitions, default ' + YOLO.get_defaults("classes_path")
     )
 


### PR DESCRIPTION
thank you for your great work.
I only found two input parameters that need to be renamed to match those in yolo.py defaults.